### PR TITLE
Store changes made in Building and Person models

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,16 @@
+# frozen_string_literal: true
+
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+  before_update :record_history
+
+  def record_history
+    return if instance_of?(History)
+
+    attributes.each_key do |key|
+      old_value = send("#{key}_was".to_sym)
+      changed = send("#{key}_changed?".to_sym)
+      History.create(column: key, value: old_value, memorable: self) if old_value && changed
+    end
+  end
 end

--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -1,2 +1,3 @@
 class Building < ApplicationRecord
+  has_many :histories, as: :memorable
 end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,0 +1,3 @@
+class History < ApplicationRecord
+  belongs_to :memorable, polymorphic: true
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,2 +1,3 @@
 class Person < ApplicationRecord
+  has_many :histories, as: :memorable
 end

--- a/db/migrate/20220427093159_create_histories.rb
+++ b/db/migrate/20220427093159_create_histories.rb
@@ -1,0 +1,12 @@
+class CreateHistories < ActiveRecord::Migration[6.1]
+  def change
+    create_table :histories do |t|
+      t.string  :column
+      t.string  :value
+      t.references :memorable, polymorphic: true
+      t.timestamps
+    end
+
+    add_index :histories, %i[memorable_type memorable_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_26_085042) do
+ActiveRecord::Schema.define(version: 2022_04_27_093159) do
 
   create_table "buildings", force: :cascade do |t|
     t.string "reference"
@@ -21,6 +21,17 @@ ActiveRecord::Schema.define(version: 2022_04_26_085042) do
     t.string "manager_name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "histories", force: :cascade do |t|
+    t.string "column"
+    t.string "value"
+    t.string "memorable_type"
+    t.integer "memorable_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["memorable_type", "memorable_id"], name: "index_histories_on_memorable"
+    t.index ["memorable_type", "memorable_id"], name: "index_histories_on_memorable_type_and_memorable_id"
   end
 
   create_table "people", force: :cascade do |t|

--- a/spec/factories/histories.rb
+++ b/spec/factories/histories.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :history do
+    column { Faker::Lorem.word }
+    value { Faker::Lorem.word }
+    memorable { create(%i[building person].sample) }
+  end
+end

--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe ApplicationRecord do
+  describe 'Callbacks' do
+    describe 'before_update' do
+      describe '#record_history' do
+        context 'when model is History' do
+          let!(:history) { create(:history) }
+
+          it 'updates the model' do
+            expect { history.update(attributes_for(:history)) }.not_to change(History, :count)
+          end
+        end
+
+        %i[building person].each do |model|
+
+          let!(:instance) { create(model) }
+          let!(:new_attributes) { attributes_for(model) }
+          let!(:number_of_changed_attributes) { new_attributes.size }
+
+          context "when model is #{model.capitalize}" do
+
+            context 'when data has been changed' do
+              it 'updates the record' do
+                instance.update(new_attributes)
+                expect(instance.reload).to have_attributes(new_attributes)
+              end
+
+              it 'saves the previous values in the History table' do
+                expect { instance.update(new_attributes) }.to change(History, :count).from(0).to(number_of_changed_attributes + 1)
+                expect(History.last.reload).to have_attributes({ memorable_type: instance.class.to_s })
+              end
+            end
+
+            context 'when data has not been changed' do
+              let(:not_so_new_attributes) { instance.attributes }
+
+              it 'updates the record but does not save history' do
+                expect { instance.update(not_so_new_attributes) }.not_to change(History, :count)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR stores every changes made in Building and Person models, when one of their record is updated.

It only stores changes truly made.

It works with an ApplicationRecord `before_update` callback and therefore works for every model in the App.

This could be improved by a conditional callback in the future.