### PR TITLE
Sanitize update from CSV

### DIFF
--- a/app/services/data_import.rb
+++ b/app/services/data_import.rb
@@ -17,7 +17,7 @@ module DataImport
     csv.each do |row|
       attributes = row.to_hash
       record = model.find_or_create_by(ID => attributes[ID])
-      shorten_attributes = attributes.reject { |key, value| sanitize?(record, key, value) }
+      shorten_attributes = attributes.reject { |key, value| sanitize?(record, key, value) }.slice(*record.attributes.keys)
       record.update!(shorten_attributes)
     end
   end

--- a/app/services/data_import.rb
+++ b/app/services/data_import.rb
@@ -2,6 +2,10 @@ require 'csv'
 
 module DataImport
   ID = 'reference'
+  SECURE_CHECK = {
+    'Building': ['manager_name'],
+    'Person': %w[email home_phone_number mobile_phone_number address]
+  }.freeze
 
   def update_from_file(file_name)
     return unless File.file?(file_name)

--- a/app/services/data_import.rb
+++ b/app/services/data_import.rb
@@ -33,4 +33,10 @@ module DataImport
   rescue NameError
     nil
   end
+
+  def sanitize?(record, key, value)
+    protected_columns = SECURE_CHECK[record.class.to_s.to_sym]
+    return false unless protected_columns&.include?(key)
+    History.where(memorable: record, column: key, value: value).present?
+  end
 end

--- a/app/services/data_import.rb
+++ b/app/services/data_import.rb
@@ -19,6 +19,9 @@ module DataImport
       record = model.find_or_create_by(ID => attributes[ID])
       record.update!(attributes)
     end
+
+  def get_protected_columns(model)
+    SECURE_CHECK[model]
   end
 
   private

--- a/app/services/data_import.rb
+++ b/app/services/data_import.rb
@@ -17,8 +17,10 @@ module DataImport
     csv.each do |row|
       attributes = row.to_hash
       record = model.find_or_create_by(ID => attributes[ID])
-      record.update!(attributes)
+      shorten_attributes = attributes.reject { |key, value| sanitize?(record, key, value) }
+      record.update!(shorten_attributes)
     end
+  end
 
   def get_protected_columns(model)
     SECURE_CHECK[model]

--- a/spec/services/data_import_spec.rb
+++ b/spec/services/data_import_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../app/services/data_import'
 
 RSpec.describe DataImport do
@@ -12,26 +14,57 @@ RSpec.describe DataImport do
       end
     end
 
-    context 'with a file not named after a model' do
+    context 'when file is not named after a model' do
       it 'returns nil' do
         allow(File).to receive(:exists?).and_return(true)
         expect(update_from_file(file_name)).to be_nil
       end
     end
 
-    context 'with a file name written as a model name' do
-      let(:file_name) { "people.csv" }
-      let!(:person1) { create(:person, reference: '1') }
+    context 'when file is names after a model' do
+      let(:file_name) { 'people.csv' }
 
-      it 'updates the record found' do
-        update_from_file(file_name)
-        expect(Person.first.reload).to have_attributes(firstname: 'Henri')
+      context 'when values are brand new' do
+        let!(:person1) { create(:person, reference: '1') }
+
+        it 'updates the record found' do
+          update_from_file(file_name)
+          expect(Person.first.reload).to have_attributes(firstname: 'Henri')
+        end
+
+        it "creates records that does'nt exist yet" do
+          update_from_file(file_name)
+          expect(Person.count).to eq(2)
+        end
       end
 
-      it "creates records that does'nt exist yet" do
-        update_from_file(file_name)
-        expect(Person.count).to eq(2)
-      end
+        context 'when values are known to history' do
+          let!(:person1) do
+            create(:person, reference: '1', email: 'h.dupont@gmail.com', home_phone_number: '0123456789',
+                   mobile_phone_number: '0623456789', firstname: 'Henri', lastname: 'Dupont', address: '10 Rue La bruyère')
+          end
+          let(:actual_attributes) { person1.attributes }
+          let(:protected_columns) { get_protected_columns(person1.class.to_s.to_sym) }
+          it 'does not update corresponding attributes' do
+            person1.update(attributes_for(:person, reference: '1'))
+            update_from_file(file_name)
+            expect(Person.first).to have_attributes(actual_attributes.slice(*protected_columns))
+          end
+        end
+
+        context 'when some values are not known to history' do
+          let!(:person1) do
+            create(:person, reference: '1', email: 'h.dupont@gmail.com', home_phone_number: '0123456789',
+                   mobile_phone_number: '0623456789', firstname: 'Henri', lastname: 'Dupont', address: Faker::Address.street_address)
+          end
+          let(:actual_attributes) { person1.attributes }
+          let(:protected_columns) { get_protected_columns(person1.class.to_s.to_sym) }
+          it 'updates only attributes without history' do
+            person1.update(attributes_for(:person, reference: '1'))
+            update_from_file(file_name)
+            expect(Person.first).to have_attributes(address: '10 Rue La bruyère')
+          end
+        end
     end
   end
 end

--- a/spec/services/data_import_spec.rb
+++ b/spec/services/data_import_spec.rb
@@ -65,6 +65,15 @@ RSpec.describe DataImport do
             expect(Person.first).to have_attributes(address: '10 Rue La bruyère')
           end
         end
+
+        context 'when a column has been removed from database' do
+          let(:person1) { create(:person, reference: '1') }
+          let(:actual_attributes) { person1.attributes }
+
+          it "doesn't raise any error"
+
+          it 'updates existing attributes'
+        end
     end
   end
 end


### PR DESCRIPTION
This PR, check previous record before updating model.

Also if a column was removed from a table, import can still going on.